### PR TITLE
Universal Video Downloader (best-effort)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,186 @@ A headless browser-based video downloader for adult streaming sites like **HQPor
 ## 🖥️ Usage
 
 ```bash
+python video_downloader.py "https://example.com/video-page"
+```
+
+You’ll be prompted to enter a video URL, e.g.
+
+```
+🔗 Enter video URL:
+https://www.hqporner.com/hdporn/some-video-title.html
+```
+
+Then you’ll see available qualities:
+
+🎥 Available Qualities:
+1. 360p
+2. 720p
+3. 1080p
+👉 Choose quality (e.g., 360p, 720p, 1080p): 720p
+
+The video will be saved to `downloads/` folder.
+
+---
+
+## 🛡️ Adblock Extension (Optional)
+
+* If `ublock_origin.xpi` is available, it will be installed temporarily into Firefox to block dynamic ads/popups.
+* If the file is missing, the script continues **without failing**.
+
+**Tip:** This can significantly improve speed and stability.
+
+---
+
+## 🧼 Known Issues
+
+* Some videos may have obfuscated or delayed source loading; script retries with basic fallbacks.
+* File names are slugified from the URL. Avoid characters like `:`, `?`, etc.
+* `iframe` detection timeout can occur if network is slow.
+* `uBlock Origin` addon may fail to install silently if Firefox is not configured properly.
+
+---
+
+## 🌐 Supported Sites
+
+| Site           | Handler Function           |
+| -------------- | -------------------------- |
+| hqporner.com   | `download_from_hqporner`   |
+| incestflix.com | `download_from_incestflix` |
+| superporn.com  | `download_from_superporn`  |
+
+*More sites can be added easily!*
+
+---
+
+## 📁 Folder Structure
+
+```
+video-downloader/
+│
+├── video_downloader.py
+├── downloads/          # Output folder
+├── README.md
+└── requirements.txt    # (optional)
+```
+
+---
+
+## 🙋 FAQ
+
+**Q: Firefox fails, what to do?**</br>
+Make sure you have Firefox installed and working. If not, Chrome will be used as a fallback.
+
+**Q: Download fails or is partial?**</br>
+Try re-running. For large files, ensure your internet connection is stable.
+
+**Q: Can I run this on a server?**</br>
+Yes, as long as you install Firefox or Chrome and run in headless mode.
+
+---
+
+
+## Useful options
+
+```bash
+python video_downloader.py "https://example.com/video-page" --list-only
+python video_downloader.py "https://example.com/video-page" -q "best[height<=720]"
+python video_downloader.py "https://example.com/video-page" --no-ytdlp
+python video_downloader.py "https://example.com/video-page" --headful
+```
+
+## Limits
+
+This script does not bypass DRM, paywalls, logins, or access controls.
+
+---
+
+## ⚠️ Disclaimer
+
+This tool is for **educational purposes only**. Please use responsibly and only on content you are legally permitted to download.
+
+
+# 🎬 Video Downloader (Selenium + TQDM)
+
+![Python](https://img.shields.io/badge/python-3.10+-blue)
+![License](https://img.shields.io/github/license/luisdiaz327/VideoScraper)
+![Issues](https://img.shields.io/github/issues/luisdiaz327/VideoScraper)
+![Last Commit](https://img.shields.io/github/last-commit/luisdiaz327/VideoScraper)
+![Stars](https://img.shields.io/github/stars/luisdiaz327/VideoScraper)
+
+![Forks](https://img.shields.io/github/forks/luisdiaz327/VideoScraper?style=social)
+
+
+
+
+A headless browser-based video downloader for adult streaming sites like **HQPorner**, **IncestFlix**, and **SuperPorn**.
+
+- ✅ Automatically detects video quality
+- ✅ Ad-removal using DOM selectors
+- ✅ Works with **Firefox** or **Chrome**
+- ✅ Optional **adblocker support** via `ublock_origin.xpi`
+- ✅ Download progress shown using `tqdm`
+
+---
+
+## 🚀 Features
+
+- Headless automation via Selenium
+- Tries Firefox first, falls back to Chrome
+- Automatically extracts video URL
+- Supports multiple video sources
+- Downloads in selected quality
+- Gracefully removes ads/popups
+
+---
+
+## ⚙️ Requirements
+
+- Python 3.7+
+- pip
+- Firefox or Chrome browser installed
+
+---
+
+## 📦 Installation
+
+1. Clone the repo:
+   ```bash
+   git clone https://github.com/yourname/video-downloader.git
+   cd video-downloader ```
+
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+   Or manually:
+
+   ```bash
+   pip install selenium requests tqdm webdriver-manager
+   ```
+
+3. *(Optional but recommended)*: Download the **uBlock Origin** `.xpi` extension and place it in the same directory as the script:
+
+   * [Download uBlock Origin for Firefox (.xpi)](https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi)
+   * Rename it to `ublock_origin.xpi`
+
+---
+
+## 🧠 How It Works
+
+1. You provide a video URL from a supported site.
+2. The script opens it in headless Firefox or Chrome.
+3. It removes ads/popups.
+4. Extracts available video sources and asks you to pick a quality.
+5. Downloads the selected stream using `requests` + `tqdm`.
+
+---
+
+## 🖥️ Usage
+
+```bash
 python video_downloader.py
 ```
 

--- a/VideoScraper.py
+++ b/VideoScraper.py
@@ -1,267 +1,580 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
 import os
+import re
+import sys
 import time
+from pathlib import Path
+from typing import Iterable, List, Optional, Set, Tuple
+from urllib.parse import urlparse, unquote
+
 import requests
+from tqdm import tqdm
+
 from selenium import webdriver
-from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from selenium.webdriver.firefox.service import Service as FirefoxService
 from selenium.webdriver.chrome.options import Options as ChromeOptions
 from selenium.webdriver.chrome.service import Service as ChromeService
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from webdriver_manager.firefox import GeckoDriverManager
 from webdriver_manager.chrome import ChromeDriverManager
-from tqdm import tqdm
-
-UBLOCK_XPI_PATH = os.path.abspath("ublock_origin.xpi")
-UBLOCK_DOWNLOAD_URL = "https://addons.mozilla.org/firefox/downloads/latest/ublock-origin/latest.xpi"
 
 
-def download_ublock():
-    """Download uBlock Origin .xpi if not present."""
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/126.0.0.0 Safari/537.36"
+)
+
+DIRECT_VIDEO_EXTS = (".mp4", ".webm", ".mov", ".m4v", ".mkv", ".avi")
+STREAM_EXTS = (".m3u8", ".mpd")
+MEDIA_MIME_HINTS = (
+    "video/",
+    "application/vnd.apple.mpegurl",
+    "application/x-mpegurl",
+    "audio/mpegurl",
+    "application/dash+xml",
+)
+
+
+def normalize_url(url: str) -> str:
+    url = url.strip()
+    if not url:
+        raise ValueError("URL is empty.")
+
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = "https://" + url
+        parsed = urlparse(url)
+
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"Invalid URL: {url}")
+
+    return url
+
+
+def sanitize_filename(name: str, fallback: str = "video") -> str:
+    name = unquote(name or "").strip()
+    name = re.sub(r"[\\/:*?\"<>|]+", "_", name)
+    name = re.sub(r"\s+", " ", name).strip(" ._")
+    return name[:160] if name else fallback
+
+
+def get_url_extension(url: str) -> str:
+    path = urlparse(url).path.lower()
+    for ext in DIRECT_VIDEO_EXTS + STREAM_EXTS:
+        if path.endswith(ext):
+            return ext
+    return ""
+
+
+def next_available_path(path: Path) -> Path:
+    if not path.exists():
+        return path
+
+    stem = path.stem
+    suffix = path.suffix
+    parent = path.parent
+
+    counter = 2
+    while True:
+        candidate = parent / f"{stem}_{counter}{suffix}"
+        if not candidate.exists():
+            return candidate
+        counter += 1
+
+
+def looks_like_media_url(url: Optional[str], mime: str = "") -> bool:
+    if not url:
+        return False
+
+    url = url.strip()
+    if not url or url.startswith(("blob:", "data:", "javascript:")):
+        return False
+
+    lower_path = urlparse(url).path.lower()
+    lower_url = url.lower()
+    lower_mime = (mime or "").lower()
+
+    # Avoid thumbnails and tiny previews when possible.
+    bad_hints = ("thumbnail", "thumb", "sprite", "poster", ".jpg", ".jpeg", ".png", ".gif")
+    if any(hint in lower_url for hint in bad_hints):
+        return False
+
+    if lower_path.endswith(DIRECT_VIDEO_EXTS + STREAM_EXTS):
+        return True
+
+    if any(hint in lower_mime for hint in MEDIA_MIME_HINTS):
+        return True
+
+    # Some CDNs hide extension but include video/stream hints in query/path.
+    stream_hints = ("m3u8", "mp4", "webm", "manifest", "master.m3u8")
+    return any(hint in lower_url for hint in stream_hints)
+
+
+def score_media_url(url: str) -> int:
+    lower = url.lower()
+    path = urlparse(url).path.lower()
+    score = 0
+
+    if path.endswith(".mp4"):
+        score += 120
+    elif path.endswith(".webm"):
+        score += 110
+    elif path.endswith(".m3u8"):
+        score += 100
+    elif path.endswith(".mpd"):
+        score += 90
+    elif path.endswith(DIRECT_VIDEO_EXTS):
+        score += 80
+
+    # Prefer likely full-quality streams.
+    if any(x in lower for x in ("1080", "1920x1080", "fhd")):
+        score += 30
+    if any(x in lower for x in ("720", "1280x720", "hd")):
+        score += 20
+    if any(x in lower for x in ("480", "360", "240")):
+        score -= 10
+
+    # Penalize obvious previews/ads.
+    if any(x in lower for x in ("preview", "trailer", "ads", "doubleclick", "tracking")):
+        score -= 40
+
+    return score
+
+
+def unique_sorted(urls: Iterable[str]) -> List[str]:
+    cleaned: Set[str] = set()
+    for url in urls:
+        if not url:
+            continue
+        url = url.strip()
+        if url.startswith("//"):
+            url = "https:" + url
+        if looks_like_media_url(url):
+            cleaned.add(url)
+
+    return sorted(cleaned, key=score_media_url, reverse=True)
+
+
+def try_ytdlp_download(
+    url: str,
+    out_dir: Path,
+    quality: str = "best",
+    referer: Optional[str] = None,
+    quiet: bool = False,
+) -> bool:
     try:
-        print("🌐 Downloading uBlock Origin...")
-        response = requests.get(UBLOCK_DOWNLOAD_URL, stream=True)
-        response.raise_for_status()
-        with open(UBLOCK_XPI_PATH, "wb") as f:
-            for chunk in response.iter_content(1024):
-                f.write(chunk)
-        print("✅ uBlock Origin downloaded.")
-    except Exception as e:
-        print(f"⚠️ Failed to download uBlock Origin: {e}")
+        import yt_dlp
+    except ImportError:
+        print("⚠️ yt-dlp is not installed. Skipping yt-dlp step.")
+        return False
 
+    out_dir.mkdir(parents=True, exist_ok=True)
 
-def setup_driver():
+    if quality == "best":
+        format_selector = "bv*+ba/best"
+    else:
+        # Examples:
+        # "best[height<=720]"
+        # "best[height<=1080]"
+        # "bv*[height<=720]+ba/best[height<=720]"
+        format_selector = quality
+
+    ydl_opts = {
+        "outtmpl": str(out_dir / "%(title).160B [%(id)s].%(ext)s"),
+        "format": format_selector,
+        "noplaylist": True,
+        "retries": 5,
+        "fragment_retries": 5,
+        "continuedl": True,
+        "merge_output_format": "mp4",
+        "quiet": quiet,
+        "no_warnings": False,
+        "http_headers": {
+            "User-Agent": USER_AGENT,
+            **({"Referer": referer} if referer else {}),
+        },
+    }
+
     try:
-        print("🦊 Trying Firefox...")
-        options = FirefoxOptions()
-        options.headless = True
-        options.set_preference("permissions.default.image", 2)
-        options.set_preference("dom.popup_maximum", 0)
-        options.set_preference("privacy.popups.showBrowserMessage", False)
-        options.set_preference("dom.disable_open_during_load", True)
-        options.set_preference("dom.popup_allowed_events", "")
+        print("🔎 Trying yt-dlp...")
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            result_code = ydl.download([url])
+        return result_code == 0
+    except Exception as exc:
+        print(f"⚠️ yt-dlp failed: {exc}")
+        return False
 
-        driver = webdriver.Firefox(
-            service=FirefoxService(GeckoDriverManager().install()),
-            options=options
-        )
 
-        # Auto-download if missing
-        if not os.path.exists(UBLOCK_XPI_PATH):
-            download_ublock()
+def create_chrome_driver(headless: bool = True) -> webdriver.Chrome:
+    options = ChromeOptions()
 
-        # Try to install uBlock if exists
-        if os.path.exists(UBLOCK_XPI_PATH):
+    if headless:
+        options.add_argument("--headless=new")
+
+    options.add_argument("--window-size=1366,768")
+    options.add_argument("--autoplay-policy=no-user-gesture-required")
+    options.add_argument("--disable-notifications")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument(f"--user-agent={USER_AGENT}")
+
+    # Enable Chrome performance logs so we can read Network events.
+    options.set_capability("goog:loggingPrefs", {"performance": "ALL"})
+
+    driver = webdriver.Chrome(
+        service=ChromeService(ChromeDriverManager().install()),
+        options=options,
+    )
+
+    try:
+        driver.execute_cdp_cmd("Network.enable", {})
+    except Exception:
+        pass
+
+    return driver
+
+
+def wait_for_page(driver: webdriver.Chrome, timeout: int = 25) -> None:
+    WebDriverWait(driver, timeout).until(
+        lambda d: d.execute_script("return document.readyState") in {"interactive", "complete"}
+    )
+    time.sleep(2)
+
+
+def collect_dom_media_urls_in_current_frame(driver: webdriver.Chrome) -> Set[str]:
+    urls: Set[str] = set()
+
+    # <video src="..."> and video.currentSrc
+    for video in driver.find_elements(By.TAG_NAME, "video"):
+        for attr in ("currentSrc", "src"):
             try:
-                driver.install_addon(UBLOCK_XPI_PATH, temporary=True)
-                print("✅ uBlock Origin installed.")
-            except Exception as addon_err:
-                print(f"⚠️ Failed to install uBlock Origin: {addon_err}")
-        else:
-            print("⚠️ uBlock Origin not installed (file missing).")
-
-        print("✅ Firefox started.")
-        return driver
-
-    except Exception as firefox_error:
-        print(f"⚠️ Firefox failed: {firefox_error}")
-        print("🧪 Trying Chrome instead...")
+                value = driver.execute_script(
+                    "return arguments[0][arguments[1]] || arguments[0].getAttribute(arguments[1]);",
+                    video,
+                    attr,
+                )
+                if looks_like_media_url(value):
+                    urls.add(value)
+            except Exception:
+                pass
 
         try:
-            chrome_options = ChromeOptions()
-            chrome_options.add_argument("--headless")
-            chrome_options.add_argument("--disable-popup-blocking")
-            chrome_options.add_argument("--disable-extensions")
-            chrome_options.add_argument("--no-sandbox")
-            chrome_options.add_argument("--disable-dev-shm-usage")
+            for source in video.find_elements(By.TAG_NAME, "source"):
+                value = source.get_attribute("src")
+                if looks_like_media_url(value):
+                    urls.add(value)
+        except Exception:
+            pass
 
-            driver = webdriver.Chrome(
-                service=ChromeService(ChromeDriverManager().install()),
-                options=chrome_options
-            )
-
-            print("✅ Chrome started.")
-            return driver
-
-        except Exception as chrome_error:
-            print(f"❌ Chrome also failed: {chrome_error}")
-            raise RuntimeError("No supported browser found. Please install Firefox or Chrome.")
-
-
-def remove_ads(driver):
-    ad_selectors = ["iframe", "popup", "ads", "adframe", "ad-container"]
-    for selector in ad_selectors:
+    # Standalone <source src="...">
+    for source in driver.find_elements(By.TAG_NAME, "source"):
         try:
-            ads = driver.find_elements(By.CSS_SELECTOR, f"[id*='{selector}'],[class*='{selector}']")
-            for ad in ads:
-                driver.execute_script("arguments[0].remove();", ad)
-        except:
+            value = source.get_attribute("src")
+            if looks_like_media_url(value):
+                urls.add(value)
+        except Exception:
+            pass
+
+    # Some players store URLs in attributes.
+    attrs_to_check = ("src", "data-src", "data-video", "data-url", "data-file")
+    css = ",".join(f"[{attr}]" for attr in attrs_to_check)
+
+    try:
+        elements = driver.find_elements(By.CSS_SELECTOR, css)
+        for element in elements:
+            for attr in attrs_to_check:
+                try:
+                    value = element.get_attribute(attr)
+                    if looks_like_media_url(value):
+                        urls.add(value)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+
+    return urls
+
+
+def collect_dom_media_urls(driver: webdriver.Chrome, max_depth: int = 3) -> Set[str]:
+    urls: Set[str] = set()
+
+    def scan_frame(depth: int) -> None:
+        urls.update(collect_dom_media_urls_in_current_frame(driver))
+
+        if depth >= max_depth:
+            return
+
+        frames = driver.find_elements(By.TAG_NAME, "iframe")
+        for index in range(len(frames)):
+            try:
+                # Re-fetch because the DOM may change after switching.
+                frames_now = driver.find_elements(By.TAG_NAME, "iframe")
+                driver.switch_to.frame(frames_now[index])
+                scan_frame(depth + 1)
+            except Exception:
+                pass
+            finally:
+                try:
+                    driver.switch_to.parent_frame()
+                except Exception:
+                    pass
+
+    driver.switch_to.default_content()
+    scan_frame(0)
+    driver.switch_to.default_content()
+
+    return urls
+
+
+def collect_network_media_urls(driver: webdriver.Chrome) -> Set[str]:
+    urls: Set[str] = set()
+
+    try:
+        logs = driver.get_log("performance")
+    except Exception as exc:
+        print(f"⚠️ Could not read performance logs: {exc}")
+        return urls
+
+    for entry in logs:
+        try:
+            message = json.loads(entry["message"]).get("message", {})
+            method = message.get("method", "")
+            params = message.get("params", {})
+
+            url = None
+            mime = ""
+
+            if method == "Network.requestWillBeSent":
+                request = params.get("request", {})
+                url = request.get("url")
+            elif method == "Network.responseReceived":
+                response = params.get("response", {})
+                url = response.get("url")
+                mime = response.get("mimeType", "")
+            else:
+                continue
+
+            if looks_like_media_url(url, mime):
+                urls.add(url)
+
+        except Exception:
             continue
 
-
-def download_file(video_url, save_path):
-    print(f"\n⬇️ Downloading to: {save_path}")
-    response = requests.get(video_url, stream=True)
-    total = int(response.headers.get('content-length', 0))
-
-    with open(save_path, "wb") as f, tqdm(
-        desc="📥 Progress",
-        total=total,
-        unit='B',
-        unit_scale=True,
-        unit_divisor=1024,
-    ) as bar:
-        for chunk in response.iter_content(chunk_size=1024 * 1024):
-            if chunk:
-                f.write(chunk)
-                bar.update(len(chunk))
-    print("✅ Download complete!")
+    return urls
 
 
-def download_from_hqporner(url, save_dir="downloads"):
-    print(f"\n🔄 Launching browser for: {url}")
-    driver = setup_driver()
-
+def gently_trigger_video_loading(driver: webdriver.Chrome) -> None:
+    """
+    This does not bypass anything. It just asks already-present video elements to load/play muted,
+    and scrolls the page so lazy-loaded players can appear.
+    """
     try:
-        driver.get(url)
-        remove_ads(driver)
-
-        iframe = WebDriverWait(driver, 10).until(
-            EC.presence_of_element_located((By.TAG_NAME, "iframe"))
+        driver.execute_script(
+            """
+            document.querySelectorAll('video').forEach(v => {
+                try {
+                    v.muted = true;
+                    v.preload = 'auto';
+                    v.load();
+                    v.play().catch(() => {});
+                } catch (e) {}
+            });
+            """
         )
-        driver.switch_to.frame(iframe)
-        remove_ads(driver)
-
-        sources = WebDriverWait(driver, 10).until(
-            EC.presence_of_all_elements_located((By.TAG_NAME, "source"))
-        )
-
-        quality_map = {}
-        for source in sources:
-            title = source.get_attribute("title") or "unknown"
-            src = source.get_attribute("src")
-            if title and src:
-                quality_map[title.lower()] = src
-
-        if not quality_map:
-            print("❌ No video sources found.")
-            return
-
-        print("\n🎥 Available Qualities:")
-        for idx, quality in enumerate(quality_map.keys(), start=1):
-            print(f"{idx}. {quality}")
-
-        choice = input("\n👉 Choose quality (e.g., 360p, 720p, 1080p): ").strip().lower()
-        selected_src = quality_map.get(choice)
-
-        if not selected_src:
-            print("❌ Invalid choice or quality not available.")
-            return
-
-        if selected_src.startswith("//"):
-            selected_src = "https:" + selected_src
-
-        print(f"🎯 Selected video URL:\n{selected_src}")
-        slug = url.strip("/").split("/")[-1]
-        filename = slug.replace("-", "_") + f"_{choice}.mp4"
-        os.makedirs(save_dir, exist_ok=True)
-        save_path = os.path.join(save_dir, filename)
-
-        download_file(selected_src, save_path)
-
-    except Exception as e:
-        print(f"❌ Error: {e}")
-    finally:
-        driver.quit()
-
-
-def download_from_incestflix(url, save_dir="downloads"):
-    print(f"\n🔄 Launching browser for: {url}")
-    driver = setup_driver()
-    driver.get(url)
-    remove_ads(driver)
-    time.sleep(5)
+    except Exception:
+        pass
 
     try:
-        video = driver.find_element(By.TAG_NAME, "video")
-        video_src = video.get_attribute("src")
-
-        if not video_src:
-            source = video.find_element(By.TAG_NAME, "source")
-            video_src = source.get_attribute("src")
-
-        if not video_src:
-            print("❌ Video source not found.")
-            return
-
-        print(f"🎯 Found video URL:\n{video_src}")
-        slug = url.strip("/").split("/")[-1]
-        filename = slug.replace("-", "_") + ".mp4"
-        os.makedirs(save_dir, exist_ok=True)
-        save_path = os.path.join(save_dir, filename)
-
-        download_file(video_src, save_path)
-
-    except Exception as e:
-        print(f"❌ Error: {e}")
-    finally:
-        driver.quit()
+        height = driver.execute_script("return Math.max(document.body.scrollHeight, document.documentElement.scrollHeight);")
+        for y in (0, height // 3, (height * 2) // 3, height):
+            driver.execute_script("window.scrollTo(0, arguments[0]);", y)
+            time.sleep(0.8)
+        driver.execute_script("window.scrollTo(0, 0);")
+    except Exception:
+        pass
 
 
-def download_from_superporn(url, save_dir="downloads"):
-    print(f"\n🔄 Launching browser for: {url}")
-    driver = setup_driver()
-    driver.get(url)
-    remove_ads(driver)
-    time.sleep(5)
+def discover_media_urls_with_selenium(
+    page_url: str,
+    wait_seconds: int = 8,
+    headless: bool = True,
+) -> List[str]:
+    driver = create_chrome_driver(headless=headless)
 
     try:
-        video = driver.find_element(By.ID, "superporn_player_html5_api")
-        video_src = video.get_attribute("src")
+        print("🌐 Opening page with Selenium...")
+        driver.get(page_url)
+        wait_for_page(driver)
 
-        if not video_src:
-            video = driver.find_element(By.TAG_NAME, "video")
-            video_src = video.get_attribute("src")
+        gently_trigger_video_loading(driver)
+        time.sleep(wait_seconds)
 
-        if not video_src:
-            source = video.find_element(By.TAG_NAME, "source")
-            video_src = source.get_attribute("src")
+        dom_urls = collect_dom_media_urls(driver)
+        network_urls = collect_network_media_urls(driver)
 
-        if not video_src:
-            print("❌ Video source not found.")
-            return
+        all_urls = unique_sorted(dom_urls | network_urls)
 
-        print(f"🎯 Found video URL:\n{video_src}")
-        slug = url.strip("/").split("/")[-1]
-        filename = slug.replace("-", "_") + ".mp4"
-        os.makedirs(save_dir, exist_ok=True)
-        save_path = os.path.join(save_dir, filename)
+        print(f"✅ Found {len(all_urls)} possible media URL(s).")
+        return all_urls
 
-        download_file(video_src, save_path)
-
-    except Exception as e:
-        print(f"❌ Error: {e}")
     finally:
         driver.quit()
 
 
-# ========== MAIN MENU ==========
+def build_output_path(page_url: str, media_url: str, out_dir: Path) -> Path:
+    parsed_page = urlparse(page_url)
+    parsed_media = urlparse(media_url)
+
+    page_slug = sanitize_filename(Path(parsed_page.path.strip("/")).name, "video")
+    media_slug = sanitize_filename(Path(parsed_media.path).stem, page_slug)
+
+    ext = get_url_extension(media_url)
+    if ext in STREAM_EXTS:
+        ext = ".mp4"
+    elif not ext:
+        ext = ".mp4"
+
+    return next_available_path(out_dir / f"{media_slug}{ext}")
+
+
+def download_direct_file(media_url: str, out_path: Path, referer: Optional[str] = None) -> bool:
+    headers = {
+        "User-Agent": USER_AGENT,
+        **({"Referer": referer} if referer else {}),
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"⬇️ Downloading direct video:")
+    print(media_url)
+    print(f"💾 Saving as: {out_path}")
+
+    try:
+        with requests.get(media_url, headers=headers, stream=True, timeout=40) as response:
+            response.raise_for_status()
+
+            total = int(response.headers.get("content-length", 0))
+            with open(out_path, "wb") as file, tqdm(
+                total=total,
+                unit="B",
+                unit_scale=True,
+                unit_divisor=1024,
+                desc="📥 Progress",
+            ) as bar:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    if chunk:
+                        file.write(chunk)
+                        bar.update(len(chunk))
+
+        print("✅ Download complete.")
+        return True
+
+    except Exception as exc:
+        print(f"❌ Direct download failed: {exc}")
+        return False
+
+
+def download_best_candidate(
+    page_url: str,
+    candidates: List[str],
+    out_dir: Path,
+    quality: str = "best",
+    list_only: bool = False,
+) -> bool:
+    if not candidates:
+        print("❌ No downloadable media URL found.")
+        return False
+
+    print("\n🎥 Possible media URLs:")
+    for i, candidate in enumerate(candidates[:20], 1):
+        print(f"{i}. {candidate}")
+
+    if list_only:
+        return True
+
+    chosen = candidates[0]
+    ext = get_url_extension(chosen)
+
+    print(f"\n🎯 Auto-selected best candidate:")
+    print(chosen)
+
+    if ext in STREAM_EXTS:
+        print("📡 Stream detected. Using yt-dlp for HLS/DASH download...")
+        return try_ytdlp_download(chosen, out_dir, quality=quality, referer=page_url)
+
+    out_path = build_output_path(page_url, chosen, out_dir)
+    return download_direct_file(chosen, out_path, referer=page_url)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Best-effort universal video downloader for authorized downloads."
+    )
+
+    parser.add_argument("url", nargs="?", help="Video page URL")
+    parser.add_argument("-o", "--out-dir", default="downloads", help="Download folder")
+    parser.add_argument(
+        "-q",
+        "--quality",
+        default="best",
+        help=(
+            "yt-dlp format selector. Examples: best, best[height<=720], "
+            "bv*[height<=1080]+ba/best[height<=1080]"
+        ),
+    )
+    parser.add_argument("--no-ytdlp", action="store_true", help="Skip yt-dlp and use Selenium discovery only")
+    parser.add_argument("--list-only", action="store_true", help="Only list discovered media URLs, do not download")
+    parser.add_argument("--headful", action="store_true", help="Show browser window instead of headless mode")
+    parser.add_argument("--wait", type=int, default=8, help="Extra seconds to wait for lazy-loaded media")
+
+    args = parser.parse_args()
+
+    url = args.url or input("🔗 Enter video page URL: ").strip()
+    out_dir = Path(args.out_dir)
+
+    try:
+        page_url = normalize_url(url)
+    except ValueError as exc:
+        print(f"❌ {exc}")
+        return 1
+
+    print("🎬 Universal Video Downloader")
+    print(f"🔗 URL: {page_url}")
+    print("⚠️ Use only where you have permission. DRM/paywall/login bypass is not supported.\n")
+
+    # Step 1: yt-dlp handles thousands of sites and many generic video pages.
+    if not args.no_ytdlp and not args.list_only:
+        if try_ytdlp_download(page_url, out_dir, quality=args.quality):
+            print("✅ Finished with yt-dlp.")
+            return 0
+
+    # Step 2: Selenium fallback.
+    candidates = discover_media_urls_with_selenium(
+        page_url,
+        wait_seconds=args.wait,
+        headless=not args.headful,
+    )
+
+    if download_best_candidate(
+        page_url,
+        candidates,
+        out_dir,
+        quality=args.quality,
+        list_only=args.list_only,
+    ):
+        return 0
+
+    print("\n❌ Could not download this video.")
+    print("Possible reasons:")
+    print("- The site uses DRM/encrypted media.")
+    print("- The video requires login or paid access.")
+    print("- The stream URL is generated after manual interaction.")
+    print("- The website blocks automated browsers.")
+    return 2
+
+
 if __name__ == "__main__":
-    print("🎬 Video Downloader")
-    try:
-        url = input("🔗 Enter video URL: \n").strip()
-        checkUrl = url.split("/")[2]
-
-        if checkUrl in ["hqporner.com", "www.hqporner.com"]:
-            download_from_hqporner(url)
-        elif checkUrl in ["incestflix.com", "www.incestflix.com"]:
-            download_from_incestflix(url)
-        elif checkUrl in ["superporn.com", "www.superporn.com"]:
-            download_from_superporn(url)
-        else:
-            print("⚠️ Unrecognized site. Attempting with IncestFlix handler...")
-            download_from_incestflix(url)
-
-    except ValueError:
-        print("❌ Invalid URL or site not supported.")
+    raise SystemExit(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ selenium>=4.15.2
 tqdm>=4.66.1
 requests>=2.31.0
 webdriver-manager>=4.0.1
+yt-dlp


### PR DESCRIPTION

Use only for videos you own, have permission to download, or that are legally
available for download. This script does not bypass DRM, paywalls, logins, or
access controls.

Strategy:
1) Try yt-dlp first.
2) If yt-dlp fails, open the page with Selenium/Chrome.
3) Collect video URLs from:
   - <video> / <source> tags
   - Chrome performance network logs
4) Download direct files with requests.
5) Download HLS/DASH streams with yt-dlp when available.